### PR TITLE
Update Tutorial

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,17 +33,12 @@ FINDPYTHON()
 
 SETUP_PROJECT()
 
-# Catkin stuff
-FIND_PACKAGE(catkin)
-CATKIN_PACKAGE()
-
 # Activate hpp-util logging if requested
 SET (HPP_DEBUG FALSE CACHE BOOL "trigger hpp-util debug output")
 IF (HPP_DEBUG)
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHPP_DEBUG")
 ENDIF()
 
-ADD_DOC_DEPENDENCY("hpp-core >= 3")
 ADD_REQUIRED_DEPENDENCY("hpp-corbaserver >= 3")
 
 # Create and install executable running the corba server
@@ -54,58 +49,4 @@ ADD_EXECUTABLE (hpp-tutorial-server
 PKG_CONFIG_USE_DEPENDENCY (hpp-tutorial-server hpp-corbaserver)
 # Install executable
 INSTALL (TARGETS hpp-tutorial-server DESTINATION ${CMAKE_INSTALL_BINDIR})
-
-
-SET(CATKIN_PACKAGE_SHARE_DESTINATION
-  ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME})
-
-install(FILES
-  launch/tutorial.launch
-  launch/tutorial_manipulation.launch
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
-  )
-install(FILES
-  urdf/pr2.urdf
-  urdf/box.urdf
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/urdf
-  )
-install(FILES
-  srdf/pr2.srdf
-  srdf/pr2_manipulation.srdf
-  srdf/box.srdf
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/srdf
-  )
-install(FILES
-  rviz/config.rviz
-  rviz/config_manipulation.rviz
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/rviz
-  )
-install (FILES
-  src/hpp/corbaserver/pr2/robot.py
-  src/hpp/corbaserver/pr2/__init__.py
-  DESTINATION ${PYTHON_SITELIB}/hpp/corbaserver/pr2)
-install (FILES
-  src/hpp/corbaserver/manipulation/pr2/robot.py
-  src/hpp/corbaserver/manipulation/pr2/__init__.py
-  DESTINATION ${PYTHON_SITELIB}/hpp/corbaserver/manipulation/pr2)
-
-# Installation for documentation
-install(FILES
-  launch/tutorial.launch
-  launch/tutorial_manipulation.launch
-  DESTINATION
-  ${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}/doxygen-html/launch
-  )
-install(FILES
-  urdf/pr2.urdf
-  urdf/box.urdf
-  DESTINATION
-  ${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}/doxygen-html/urdf
-  )
-install(FILES
-  script/tutorial_1.py
-  script/tutorial_2.py
-  DESTINATION
-  ${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}/doxygen-html/script
-  )
 SETUP_PROJECT_FINALIZE()

--- a/script/tutorial_2.py
+++ b/script/tutorial_2.py
@@ -2,11 +2,11 @@ from hpp.corbaserver.pr2 import Robot
 robot = Robot ('pr2')
 robot.setJointBounds ("base_joint_xy", [-4, -3, -5, -3])
 
-from hpp_ros import ScenePublisher
-r = ScenePublisher (robot)
-
 from hpp.corbaserver import ProblemSolver
 ps = ProblemSolver (robot)
+
+from hpp.gepetto import Viewer
+r = Viewer (ps)
 
 q_init = robot.getCurrentConfig ()
 q_goal = q_init [::]
@@ -26,14 +26,14 @@ rank = robot.rankInConfiguration ['r_elbow_flex_joint']
 q_goal [rank] = -0.5
 r (q_goal)
 
-ps.loadObstacleFromUrdf ("iai_maps", "kitchen_area", "")
+r.loadObstacleModel ("iai_maps", "kitchen_area", "kitchen")
 
 ps.setInitialConfig (q_init)
 ps.addGoalConfig (q_goal)
 ps.selectPathPlanner ("PRM")
 ps.solve ()
 
-from hpp_ros import PathPlayer
+from hpp.gepetto import PathPlayer
 pp = PathPlayer (robot.client, r)
 
 pp (0)


### PR DESCRIPTION
J'ai modifié hpp_tutorial en accord avec Florent : le CMakeLists.txt n'utilise plus les dépendances de ROS qui étaient obselètes et tutorial_2.py a été mis à jours pour utiliser gepetto-viewer au lieu de RVIZ.

Les dossiers hpp_tutorial/urdf/ ,  hpp_tutorial/srdf/ , hpp_tutorial/rviz et hpp_tutorial/launch/ et le fichier package.xml semblent maintenant inutilisés.


