### PR TITLE
Remove ros dependencies in CMakeLists and update tutorial_2.py in order to use gepetto-viewer instead of RVIZ

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,11 +60,6 @@ SET(CATKIN_PACKAGE_SHARE_DESTINATION
   ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME})
 
 install(FILES
-  launch/tutorial.launch
-  launch/tutorial_manipulation.launch
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
-  )
-install(FILES
   urdf/pr2.urdf
   urdf/box.urdf
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/urdf
@@ -74,11 +69,6 @@ install(FILES
   srdf/pr2_manipulation.srdf
   srdf/box.srdf
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/srdf
-  )
-install(FILES
-  rviz/config.rviz
-  rviz/config_manipulation.rviz
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/rviz
   )
 install (FILES
   src/hpp/corbaserver/pr2/robot.py
@@ -90,12 +80,6 @@ install (FILES
   DESTINATION ${PYTHON_SITELIB}/hpp/corbaserver/manipulation/pr2)
 
 # Installation for documentation
-install(FILES
-  launch/tutorial.launch
-  launch/tutorial_manipulation.launch
-  DESTINATION
-  ${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}/doxygen-html/launch
-  )
 install(FILES
   urdf/pr2.urdf
   urdf/box.urdf

--- a/script/tutorial_2.py
+++ b/script/tutorial_2.py
@@ -2,11 +2,11 @@ from hpp.corbaserver.pr2 import Robot
 robot = Robot ('pr2')
 robot.setJointBounds ("base_joint_xy", [-4, -3, -5, -3])
 
-from hpp_ros import ScenePublisher
-r = ScenePublisher (robot)
-
 from hpp.corbaserver import ProblemSolver
 ps = ProblemSolver (robot)
+
+from hpp.gepetto import Viewer
+r = Viewer (ps)
 
 q_init = robot.getCurrentConfig ()
 q_goal = q_init [::]
@@ -26,14 +26,14 @@ rank = robot.rankInConfiguration ['r_elbow_flex_joint']
 q_goal [rank] = -0.5
 r (q_goal)
 
-ps.loadObstacleFromUrdf ("iai_maps", "kitchen_area", "")
+r.loadObstacleModel ("iai_maps", "kitchen_area", "kitchen")
 
 ps.setInitialConfig (q_init)
 ps.addGoalConfig (q_goal)
 ps.selectPathPlanner ("PRM")
 ps.solve ()
 
-from hpp_ros import PathPlayer
+from hpp.gepetto import PathPlayer
 pp = PathPlayer (robot.client, r)
 
 pp (0)


### PR DESCRIPTION
I made an error when I merged my commit before the last pull request, this is the real modifications.

Sorry for the inconvenience.