### PR TITLE
Remove reference to deprecated class

### DIFF
--- a/src/tutorial.cc
+++ b/src/tutorial.cc
@@ -18,7 +18,7 @@
 
 #include <hpp/util/pointer.hh>
 
-#include <hpp/core/basic-configuration-shooter.hh>
+#include <hpp/core/configuration-shooter/uniform.hh>
 #include <hpp/core/config-validations.hh>
 #include <hpp/core/connected-component.hh>
 #include <hpp/core/constraint-set.hh>
@@ -117,7 +117,8 @@ namespace hpp {
       Planner (const core::Problem& problem,
 	       const core::RoadmapPtr_t& roadmap) :
 	core::PathPlanner (problem, roadmap),
-	shooter_ (core::BasicConfigurationShooter::create (problem.robot ()))
+	shooter_ (core::configurationShooter::Uniform::create
+                  (problem.robot ()))
       {
       }
       /// Store weak pointer to itself
@@ -128,7 +129,7 @@ namespace hpp {
       }
     private:
       /// Configuration shooter to uniformly shoot random configurations
-      core::BasicConfigurationShooterPtr_t shooter_;
+      core::configurationShooter::UniformPtr_t shooter_;
       /// weak pointer to itself
       PlannerWkPtr_t weakPtr_;
     }; // class Planner


### PR DESCRIPTION
  hpp::core::BasicConfigurationShooter ->
    hpp::core::configurationShooter::Uniform.